### PR TITLE
Potential fix for code scanning alert no. 1: Exception text reinterpreted as HTML

### DIFF
--- a/public/frontend/assets/vendor/php-email-form/validate.js
+++ b/public/frontend/assets/vendor/php-email-form/validate.js
@@ -78,7 +78,7 @@
 
   function displayError(thisForm, error) {
     thisForm.querySelector('.loading').classList.remove('d-block');
-    thisForm.querySelector('.error-message').innerHTML = error;
+    thisForm.querySelector('.error-message').textContent = error;
     thisForm.querySelector('.error-message').classList.add('d-block');
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/abdullahrather/CrudOperations-Laravel/security/code-scanning/1](https://github.com/abdullahrather/CrudOperations-Laravel/security/code-scanning/1)

To fix the issue, the `error` variable should be sanitized or escaped before being inserted into the DOM. This ensures that any potentially malicious content is rendered as plain text rather than being interpreted as HTML or JavaScript. The best approach is to use `textContent` instead of `innerHTML` for inserting plain text, as `textContent` automatically escapes any special characters.

Changes to make:
1. Replace the use of `innerHTML` on line 81 with `textContent`.
2. Ensure that all error messages passed to `displayError` are plain text. If there is any possibility of HTML content being required, use a trusted library like `DOMPurify` to sanitize the input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
