### PR TITLE
fix(npm): bump vite to ^6.4.2 to resolve all Dependabot Vite CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     },
     "devDependencies": {
         "axios": "^1.1.2",
-        "laravel-vite-plugin": "^0.7.2",
+        "laravel-vite-plugin": "^2.0",
         "lodash": "^4.17.19",
         "postcss": "^8.1.14",
-        "vite": "^4.0.0"
+        "vite": "^6.4.2"
     }
 }


### PR DESCRIPTION
Fixes three Vite security vulnerabilities:
- #10: server.fs settings not applied to HTML files (vite <= 5.4.19, fixed in 5.4.20)
- #11: public dir middleware path traversal bypass (vite <= 5.4.19, fixed in 5.4.20)
- #20: .map path traversal in optimized deps handler (vite <= 6.4.1, fixed in 6.4.2)

vite 6.4.2 supersedes all three patched versions.
Also bump laravel-vite-plugin to ^2.0 for Vite 6 compatibility.